### PR TITLE
Feature: Add AI category for tasks with AI label

### DIFF
--- a/jirafly/cli.py
+++ b/jirafly/cli.py
@@ -156,8 +156,8 @@ def ratio(
 
     tasks: dict[str, dict[str, Any]] = defaultdict(
         lambda: {
-            "ratio": {"Maintenance": 0, "Bug": 0, "Product": 0, "Excluded": 0},
-            "time": {"Maintenance": 0, "Bug": 0, "Product": 0, "Excluded": 0},
+            "ratio": {"Maintenance": 0, "Bug": 0, "Product": 0, "AI": 0, "Excluded": 0},
+            "time": {"Maintenance": 0, "Bug": 0, "Product": 0, "AI": 0, "Excluded": 0},
             "tasks": [],
         }
     )
@@ -183,17 +183,19 @@ def ratio(
         "Status",
     ]
 
-    total_maintenance = total_product = total_excluded = 0
+    total_maintenance = total_product = total_excluded = total_ai = 0
     time_total_maintenance = time_total_product = 0
 
     for _, (fix_version, data) in enumerate(sorted_tasks.items()):
         maintenance = data["ratio"]["Maintenance"]
         product = data["ratio"]["Product"] + data["ratio"]["Bug"]
         excluded = data["ratio"]["Excluded"]
+        ai = data["ratio"]["AI"]
 
         total_maintenance += maintenance
         total_product += product
         total_excluded += excluded
+        total_ai += ai
 
         time_maintenance = data["time"]["Maintenance"]
         time_product = data["time"]["Product"] + data["time"]["Bug"]
@@ -243,7 +245,7 @@ def ratio(
 
         if fix_version in team_config.working_days_per_sprint:
             working_days_total = team_config.working_days_per_sprint[fix_version].total
-            efficiency = f"{(total + excluded) / working_days_total:.2f}"
+            efficiency = f"{(total + excluded + ai) / working_days_total:.2f}"
             efficiency_str = (
                 f"{colored(efficiency, 'black', on_color='on_yellow', attrs=['bold'])}"
             )
@@ -257,7 +259,7 @@ def ratio(
                 "",
                 "",
                 colored(f"{maintenance_str}  |  {product_str}", attrs=["bold"]),
-                colored(f"{total + excluded:.2f}", attrs=["bold"]),
+                colored(f"{total + excluded + ai:.2f}", attrs=["bold"]),
                 format_seconds(time_total_spent),
                 efficiency_str,
                 working_days_total,
@@ -283,7 +285,7 @@ def ratio(
             "",
             colored("Total", attrs=["bold"]),
             colored(f"{maintenance_str}  |  {product_str}", attrs=["bold"]),
-            f"{_total + total_excluded:.2f}",
+            f"{_total + total_excluded + total_ai:.2f}",
             "",
             "",
             "",

--- a/jirafly/models.py
+++ b/jirafly/models.py
@@ -68,6 +68,8 @@ class Task:
         labels = fields.get("labels", [])
         if any(label in labels for label in ["RatioExcluded", "Bughunting"]):
             task.ratio_type = "Excluded"
+        elif "AI" in labels:
+            task.ratio_type = "AI"
         elif any(label in labels for label in ["Maintenance", "DevOps"]):
             task.ratio_type = "Maintenance"
         elif task.type == "Bug":
@@ -122,6 +124,8 @@ class Task:
             color = "cyan"
         elif self.ratio_type == "Excluded":
             color = "light_magenta"
+        elif self.ratio_type == "AI":
+            color = "yellow"
 
         formatted_title = f"{self.type_fmt} {colored(title, color)}"
         return f"{formatted_title}\n{self.url_fmt}" if verbose else f"{formatted_title}"

--- a/jirafly/utils.py
+++ b/jirafly/utils.py
@@ -47,6 +47,7 @@ def print_general_info(tasks_by_assignee: dict[str, MemberPlan], current_sprint:
         "Maintenance": 0.0,
         "Bug": 0.0,
         "Product": 0.0,
+        "AI": 0.0,
         "Excluded": 0.0,
     }
     hle_assigned = deepcopy(hle_all)
@@ -57,9 +58,12 @@ def print_general_info(tasks_by_assignee: dict[str, MemberPlan], current_sprint:
             if task.is_assigned:
                 hle_assigned[task.ratio_type] += task.hle
 
-    total = hle_all["Maintenance"] + hle_all["Bug"] + hle_all["Product"]
+    total = hle_all["Maintenance"] + hle_all["Bug"] + hle_all["Product"] + hle_all["AI"]
     total_assigned = (
-        hle_assigned["Maintenance"] + hle_assigned["Bug"] + hle_assigned["Product"]
+        hle_assigned["Maintenance"]
+        + hle_assigned["Bug"]
+        + hle_assigned["Product"]
+        + hle_assigned["AI"]
     )
 
     print(
@@ -73,13 +77,26 @@ def print_general_info(tasks_by_assignee: dict[str, MemberPlan], current_sprint:
     table.add_row(["", "Assigned", "All"], divider=True)
     table.add_row(
         [
-            colored(" Maintenance ", color="black", on_color="on_cyan"),
+            colored(" AI", color="yellow"),
             colored(
-                f"{hle_assigned['Maintenance']:.2f} MD ({hle_assigned['Maintenance'] / total_assigned * 100:5.2f} %)",
+                f"{hle_assigned['AI']:.2f} MD ({safe_percentage(hle_assigned['AI'], total_assigned):5.2f} %)",
+                color="yellow",
+            ),
+            colored(
+                f"{hle_all['AI']:.2f} MD ({safe_percentage(hle_all['AI'], total):5.2f} %)",
+                color="yellow",
+            ),
+        ],
+    )
+    table.add_row(
+        [
+            colored(" Maintenance", color="cyan"),
+            colored(
+                f"{hle_assigned['Maintenance']:.2f} MD ({safe_percentage(hle_assigned['Maintenance'], total_assigned):5.2f} %)",
                 color="cyan",
             ),
             colored(
-                f"{hle_all['Maintenance']:.2f} MD ({hle_all['Maintenance'] / total * 100:5.2f} %)",
+                f"{hle_all['Maintenance']:.2f} MD ({safe_percentage(hle_all['Maintenance'], total):5.2f} %)",
                 color="cyan",
             ),
         ],
@@ -87,20 +104,20 @@ def print_general_info(tasks_by_assignee: dict[str, MemberPlan], current_sprint:
     table.add_row(
         [
             " Bugs",
-            f"{hle_assigned['Bug']:.2f} MD ({hle_assigned['Bug'] / total_assigned * 100:5.2f} %)",
-            f"{hle_all['Bug']:.2f} MD ({hle_all['Bug'] / total * 100:5.2f} %)",
+            f"{hle_assigned['Bug']:.2f} MD ({safe_percentage(hle_assigned['Bug'], total_assigned):5.2f} %)",
+            f"{hle_all['Bug']:.2f} MD ({safe_percentage(hle_all['Bug'], total):5.2f} %)",
         ],
     )
     table.add_row(
         [
             " Product",
-            f"{hle_assigned['Product']:.2f} MD ({hle_assigned['Product'] / total_assigned * 100:5.2f} %)",
-            f"{hle_all['Product']:.2f} MD ({hle_all['Product'] / total * 100:5.2f} %)",
+            f"{hle_assigned['Product']:.2f} MD ({safe_percentage(hle_assigned['Product'], total_assigned):5.2f} %)",
+            f"{hle_all['Product']:.2f} MD ({safe_percentage(hle_all['Product'], total):5.2f} %)",
         ],
     )
     table.add_row(
         [
-            colored(" Excluded ", color="black", on_color="on_magenta"),
+            colored(" Excluded", color="magenta"),
             colored(f"{hle_assigned['Excluded']:.2f} MD", color="magenta"),
             colored(f"{hle_all['Excluded']:.2f} MD", color="magenta"),
         ],


### PR DESCRIPTION
## Summary
- Nová kategorie `AI` pro tasky s labelem `AI` v Jiře (priorita: `RatioExcluded` > `AI` > ostatní).
- V planning general info tabulce přibyl samostatný žlutý řádek `AI` mezi `Bugs` a `Product` pro lepší rozpočítání kapacity. AI tasky se v planning task listu zobrazí žlutě.
- V ratio command je AI samostatná kategorie (nezapočítává se do Maintenance/Product ratia), ale její HLE je zahrnuto do efficiency výpočtu i do Total HLE buňky.
- Drobný refactor: procenta v `print_general_info` přepsána na `safe_percentage`, aby se předešlo dělení nulou.

## Test plan
- [ ] `uv run pre-commit run --all-files` projde
- [ ] `uv run jirafly planning <sprint> configs/team.yaml` zobrazí žlutý řádek `AI` v general info tabulce
- [ ] Tasky s labelem `AI` jsou v planning task listu obarveny žlutě
- [ ] `uv run jirafly ratio configs/team.yaml` zahrnuje AI HLE do efficiency a Total HLE
- [ ] Task s labely `AI` + `RatioExcluded` je zařazen jako `Excluded` (priorita)